### PR TITLE
fixing warnings with newest elixir

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule Exmerl.Mixfile do
      version: "0.1.1",
      elixir: ">= 0.13.2",
      deps: [],
-     package: package,
-     description: description
+     package: package(),
+     description: description()
     ]
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,7 +6,7 @@ defmodule PathHelpers do
   end
 
   def fixture_path(extra) do
-    Path.join(fixture_path, extra)
+    Path.join(fixture_path(), extra)
   end
 end
 
@@ -25,8 +25,10 @@ defmodule TestHelpers do
 
   def result(suffix, opts) do
     loc = Path.dirname(__DIR__) <> suffix
-    if Keyword.get(opts, :char_list, false) do
-      loc = to_char_list loc
+    loc = if Keyword.get(opts, :char_list, false) do
+      to_char_list loc
+    else
+      loc
     end
     {
       :xmlElement, :root, :root, [], { :xmlNamespace, [], [] }, [], 1, [],


### PR DESCRIPTION
Hello,

This pull fixes a few warnings thrown with newest elixirs, like 1.3.0 and 1.4.0.

Thank you!

Best regards,